### PR TITLE
set testInvironment to false to hide facets and toc max results to ...

### DIFF
--- a/src/main/resources/config/reposis_openagrar/mycore.properties
+++ b/src/main/resources/config/reposis_openagrar/mycore.properties
@@ -24,7 +24,7 @@
 # piwikID=35
 
 # this is a productive environment
-  MIR.testEnvironment=true
+  MIR.testEnvironment=false
 
 # add oa specific searchfields
   MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-document%,openagrar-solr.xsl
@@ -37,6 +37,9 @@
 
 # specify citation styles
   MIR.citationStyles=apa,elsevier-harvard,springer-basic-author-date,din-1505-2
+
+# Maximum number of publications that can be outputted within toc
+  MIR.TableOfContents.MaxResults=10000
 
 
 ##############################################################################


### PR DESCRIPTION
10.000, some articles are already missing in toc (default was 1.000)

vgl. https://www.openagrar.de/receive/zimport_mods_00002381

-> 1951 klappt nicht aus