### PR TITLE
OA-282 adds a hot fix to prevent line break and strange alignment of …

### DIFF
--- a/src/main/resources/META-INF/resources/mir-layout/scss/project_styles/_common.scss
+++ b/src/main/resources/META-INF/resources/mir-layout/scss/project_styles/_common.scss
@@ -14,10 +14,16 @@ h4.mir-toc-section-title {
   color: #444;
 }
 
-.mir-toc-section-object-link, .mir-toc-section-page, .mir-toc-section-author {
+.mir-toc-section-object-link,
+.mir-toc-section-page,
+.mir-toc-section-author {
   line-height: 1.1;
   color: #999;
   font-size: smaller;
+}
+
+.mir-toc-section-label {
+  display: inline;
 }
 
 // Large devices (desktops) and below: <= 1200px


### PR DESCRIPTION
…list icon

https://jira.gbv.de/browse/OA-282

Was not able to test it local.
Its a workaround. Seems we need some concept work here.
Why do we have a chevron, when there is nothing to enlarge or hide?
And Chevron is not very good as mark for every list item.