### PR TITLE
OA-237 Saubere Erfassung von mehreren Berichtsjahren

### DIFF
--- a/src/main/resources/META-INF/resources/editor/editor-customization.xed
+++ b/src/main/resources/META-INF/resources/editor/editor-customization.xed
@@ -491,7 +491,7 @@
       <xed:repeat xpath="annualReviewComposit">
         <div class="mir-fieldset-content">
           <xed:bind xpath="mods:classification[@displayLabel='annual_review'][@authorityURI='https://www.openagrar.de/classifications/annual_review']">
-            <div class="form-group row  oa-noteLocationCorp">
+            <div class="form-group row">
               <label class="col-md-3 col-form-label text-right">
                 <xed:output i18n="oa.annualReview" />
               </label>
@@ -504,7 +504,7 @@
                     </select>
                   </div>
                 </div>
-                <mir:help-pmud help-text="{i18n:oa.help.annualReview}" pmud="false" />
+                <mir:help-pmud help-text="{i18n:oa.help.annualReview}" pmud="true" />
               </xed:bind>
             </div>
             <mir:textfield xpath="@edition" label="oa.annualReview.edition" placeholder="{i18n:oa.placeholder.annualReview}" 
@@ -534,7 +534,7 @@
                   </xed:bind>
                 </xed:bind>  
             </div>
-            <mir:help-pmud help-text="{i18n:mir.help.institutes}" pmud="true" />
+            <mir:help-pmud help-text="{i18n:mir.help.institutes}" pmud="false" />
           </div>
 
           <mir:textarea xpath="mods:note[@type='admin']" label="mir.comment" help-text="{i18n:mir.help.comment}" rows="3" />

--- a/src/main/resources/META-INF/resources/editor/editor-customization.xed
+++ b/src/main/resources/META-INF/resources/editor/editor-customization.xed
@@ -488,32 +488,34 @@
       <legend class="mir-fieldset-legend">
         <xed:output i18n="oa.fieldset" />
       </legend>
-      <div class="mir-fieldset-content">
-        <xed:bind xpath="mods:classification[@displayLabel='annual_review'][@authorityURI='https://www.openagrar.de/classifications/annual_review']">
-          <div class="form-group row">
-            <label class="col-md-3 col-form-label text-right">
-              <xed:output i18n="oa.annualReview" />
-            </label>
-            <xed:bind xpath="@valueURIxEditor" initially="">
-              <div class="col-md-6">
-                <div class="controls">
-                  <select class="form-control form-control-inline">
-                    <option value=""><xed:output i18n="mir.select.optional" /></option>
-                    <xed:include uri="xslStyle:items2options:classification:editor:-1:children:annual_review" />
-                  </select>
+      <xed:repeat xpath="annualReviewComposit">
+        <div class="mir-fieldset-content">
+          <xed:bind xpath="mods:classification[@displayLabel='annual_review'][@authorityURI='https://www.openagrar.de/classifications/annual_review']">
+            <div class="form-group row  oa-noteLocationCorp">
+              <label class="col-md-3 col-form-label text-right">
+                <xed:output i18n="oa.annualReview" />
+              </label>
+              <xed:bind xpath="@valueURIxEditor" initially="">
+                <div class="col-md-6">
+                  <div class="controls">
+                    <select class="form-control form-control-inline">
+                     <option value=""><xed:output i18n="mir.select.optional" /></option>
+                     <xed:include uri="xslStyle:items2options:classification:editor:-1:children:annual_review" />
+                    </select>
+                  </div>
                 </div>
-              </div>
-              <mir:help-pmud help-text="{i18n:oa.help.annualReview}" pmud="false" />
-            </xed:bind>
-          </div>
-          <mir:textfield xpath="@edition" label="oa.annualReview.edition" placeholder="{i18n:oa.placeholder.annualReview}" id="oa-annualReview-edition" />
-          <xed:if test="//mods:classification/@edition">
-                  <xed:validate xpath="//mods:classification/@edition" min="1000" max="9999" type="integer" i18n="mir.validation.edition" display="global" />
-          </xed:if>
-        </xed:bind>
+                <mir:help-pmud help-text="{i18n:oa.help.annualReview}" pmud="false" />
+              </xed:bind>
+            </div>
+            <mir:textfield xpath="@edition" label="oa.annualReview.edition" placeholder="{i18n:oa.placeholder.annualReview}" 
+              id="oa-annualReview-edition" />
+            <xed:if test="//mods:classification/@edition">
+              <xed:validate xpath="//mods:classification/@edition" min="1000" max="9999" type="integer" 
+                i18n="mir.validation.edition" display="global" />
+            </xed:if>
+          </xed:bind>
 
-        <xed:repeat xpath="noteLocationCorp">
-          <div class="form-group row oa-noteLocationCorp">
+          <div class="form-group row">
             <label class="col-md-3 col-form-label text-right">
               <xed:output i18n="mir.institution" />
               :
@@ -522,23 +524,24 @@
               <xed:load-resource name="mir_institutes" uri="classification:metadata:-1:children:mir_institutes" />
               <xed:bind xpath="mods:name[@type='corporate'][@authorityURI=$mir_institutes/label[@xml:lang='x-uri']/@text]">
                 <xed:bind xpath="mods:role/mods:roleTerm[@authority='marcrelator'][@type='code']" initially="his" /><!--  Host institution [his] -->
-                <xed:bind xpath="@valueURIxEditor">
-                  <select class="form-control form-control-inline">
-                    <option value="">
-                      <xed:output i18n="mir.select.optional" />
-                    </option>
-                    <xed:include uri="xslStyle:items2options:classification:editor:-1:children:mir_institutes" />
-                  </select>
-                </xed:bind>
-              </xed:bind>
+                  <xed:bind xpath="@valueURIxEditor">
+                    <select class="form-control form-control-inline">
+                      <option value="">
+                        <xed:output i18n="mir.select.optional" />
+                      </option>
+                      <xed:include uri="xslStyle:items2options:classification:editor:-1:children:mir_institutes" />
+                    </select>
+                  </xed:bind>
+                </xed:bind>  
             </div>
             <mir:help-pmud help-text="{i18n:mir.help.institutes}" pmud="true" />
           </div>
 
           <mir:textarea xpath="mods:note[@type='admin']" label="mir.comment" help-text="{i18n:mir.help.comment}" rows="3" />
           <mir:textfield xpath="mods:location/mods:physicalLocation" label="oa.physicalLocation" help-text="{i18n:oa.help.physicalLocation}" />
-        </xed:repeat>
-      </div>
+        </div>
+      </xed:repeat>
+
     </fieldset>
   </xed:template>
   

--- a/src/main/resources/xsl/editor/oa-mods2xeditor.xsl
+++ b/src/main/resources/xsl/editor/oa-mods2xeditor.xsl
@@ -11,16 +11,30 @@
   <xsl:template match="mods:mods">
     <xsl:copy>
       <xsl:apply-templates select="@*" />
-      <xsl:apply-templates
-        select="*[not( (local-name()='name' and @ID and @type='corporate') or (starts-with(@xlink:href,'#')) or (starts-with(mods:physicalLocation/@xlink:href,'#')) )]" />
+      <xsl:apply-templates 
+        select="*[not( (local-name()='name' and @ID and @type='corporate')  or (contains(@authorityURI,'annual_review'))
+        or (starts-with(@xlink:href,'#')) or 
+        (starts-with(mods:physicalLocation/@xlink:href,'#')))]" />
       <xsl:for-each select="mods:name[@ID and @type='corporate']">
-        <noteLocationCorp>
+        <annualReviewComposit>
           <xsl:variable name="ID" select="@ID" />
-          <xsl:apply-templates select=".|../*[@xlink:href=concat('#',$ID) or mods:physicalLocation/@xlink:href=concat('#',$ID)]" />
-        </noteLocationCorp>
+          <xsl:choose>
+            <xsl:when test="../mods:classification[@IDREF=$ID]">
+              <xsl:apply-templates select=".|../*[@xlink:href=concat('#',$ID) or 
+                mods:physicalLocation/@xlink:href=concat('#',$ID)] | ../*[@IDREF=$ID]" />
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:apply-templates select=".|../*[@xlink:href=concat('#',$ID) or 
+                mods:physicalLocation/@xlink:href=concat('#',$ID)] | 
+                ../mods:classification[contains(@authorityURI,'annual_review')]" />
+            </xsl:otherwise>
+          </xsl:choose>         
+        </annualReviewComposit>
       </xsl:for-each>
     </xsl:copy>
   </xsl:template>
+  
+  <!-- <xsl:template match="mods:classification[contains(@authorityURI,'annual_review')]"/> -->
   
   <!-- <xsl:template match="mods:affiliation[starts-with(@xlink:href,'https://www.openagrar.de/classifications/mir_institutes#']">
     <mods:affiliation>

--- a/src/main/resources/xsl/editor/oa-xeditor2mods.xsl
+++ b/src/main/resources/xsl/editor/oa-xeditor2mods.xsl
@@ -9,7 +9,7 @@
   exclude-result-prefixes="xlink mcr acl" version="1.0"
 >
 
-  <xsl:template match="noteLocationCorp">
+  <xsl:template match="annualReviewComposit">
     <xsl:variable name="repeaterId">
       <xsl:choose>
         <xsl:when test="mods:name/@ID">
@@ -23,6 +23,14 @@
     <xsl:apply-templates select="mods:name" mode="addIDToName">
       <xsl:with-param name="ID" select="$repeaterId" />
     </xsl:apply-templates>
+    <xsl:for-each select="mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review']">
+      <xsl:copy>
+        <xsl:attribute name="IDREF">
+          <xsl:value-of select="$repeaterId" />
+        </xsl:attribute>
+        <xsl:apply-templates select='@*|node()' />
+      </xsl:copy>
+    </xsl:for-each>
     <xsl:for-each select="mods:note">
       <xsl:copy>
         <xsl:attribute name="xlink:href" namespace="http://www.w3.org/1999/xlink">
@@ -44,6 +52,8 @@
       </xsl:copy>
     </xsl:for-each>
   </xsl:template>
+  
+  <xsl:template match="mods:classification[contains(@authorityURI,'annual_review') and not(@IDREF)]"/> 
 
   <xsl:template match="mods:name" mode="addIDToName">
     <xsl:param name="ID" />
@@ -55,6 +65,7 @@
     </xsl:copy>
   </xsl:template>
   
+
   <!-- <xsl:template match="mods:affiliation[@xlink:href='https://www.openagrar.de/classifications/mir_institutes#']">
     <mods:affiliation>
       <xsl:attribute name="xlink:href">

--- a/src/main/resources/xsl/metadata/mir-metadata-box.xsl
+++ b/src/main/resources/xsl/metadata/mir-metadata-box.xsl
@@ -331,8 +331,6 @@
               <xsl:apply-templates mode="oa" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:extension[@type='characteristics']" />
               <xsl:apply-templates mode="oa" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem/mods:extension[@type='metrics']" />
               <xsl:apply-templates mode="oa" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:extension[@type='metrics']" />
-              <xsl:apply-templates mode="present" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review']" />
-              <xsl:apply-templates mode="oa" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review']/@edition" />
             </xsl:if>
             
             <xsl:apply-templates mode="oa" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:name[@type='corporate'][@ID or @authorityURI=$institutesURI]" />
@@ -345,6 +343,8 @@
 
 
   <!-- OA specific templates -->
+  
+  <!-- OA specific templates -->
   <xsl:template match="mods:name[@type='corporate' and @ID]" mode="oa">
     <xsl:variable name="id" select="concat('#', @ID)" />
     <tr>
@@ -356,23 +356,36 @@
       </td>
     </tr>
     <xsl:if
-      test="(not(mcrxsl:isCurrentUserGuestUser()) and ./../mods:note[@xlink:href=$id]) or (./../mods:location/mods:physicalLocation[@xlink:href=$id])">
+      test="(not(mcrxsl:isCurrentUserGuestUser()) and ./../mods:note[@xlink:href=$id]) or (./../mods:location/mods:physicalLocation[@xlink:href=$id]) 
+        or (../../mods:mods/mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review'])">
       <tr>
         <td colspan="2">
           <table class="metaData">
+            <xsl:call-template name="printMetaDate.mods">
+              <xsl:with-param name="nodes" select="./../mods:location/mods:physicalLocation[@xlink:href=$id]" />
+            </xsl:call-template>
             <xsl:if test="not(mcrxsl:isCurrentUserGuestUser())">
+			  <xsl:variable name="idref"><xsl:value-of select="substring-after($id, '#')"/></xsl:variable>
+              <xsl:choose>
+			    <xsl:when test="../../mods:mods/mods:classification/@IDREF">								
+			      <xsl:apply-templates mode="present" select="../../mods:mods/mods:classification[@IDREF=$idref]" />
+			      <xsl:apply-templates mode="oa" select="../../mods:mods/mods:classification[@IDREF=$idref]/@edition" />
+			    </xsl:when>
+                <xsl:otherwise>
+				  <xsl:apply-templates mode="present" select="../../mods:mods/mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review']" />
+			      <xsl:apply-templates mode="oa" select="../../mods:mods/mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review']/@edition" />
+                </xsl:otherwise>
+			  </xsl:choose>
               <xsl:call-template name="printMetaDate.mods">
                 <xsl:with-param name="nodes" select="./../mods:note[@xlink:href=$id]" />
               </xsl:call-template>
             </xsl:if>
-            <xsl:call-template name="printMetaDate.mods">
-              <xsl:with-param name="nodes" select="./../mods:location/mods:physicalLocation[@xlink:href=$id]" />
-            </xsl:call-template>
           </table>
         </td>
       </tr>
     </xsl:if>
   </xsl:template>
+  
 
   <xsl:template name="printMetaDate.mods.relatedItem.oa">
     <xsl:param name="parentID" />
@@ -569,7 +582,6 @@
   </xsl:template>
 
   <xsl:template match="mods:classification[@authorityURI='https://www.openagrar.de/classifications/annual_review']/@edition" mode="oa">
-    <xsl:if test="not(mcrxsl:isCurrentUserGuestUser())">
         <tr>
           <td valign="top" class="metaname">
             <xsl:value-of select="concat(i18n:translate('component.mods.metaData.dictionary.annual_review.edition'),':')" />
@@ -578,7 +590,6 @@
             <xsl:value-of select="." />
           </td>
         </tr>
-      </xsl:if>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Jahresberichte werden über ein IDREF-Attribut den Institutionen zugeordnet. (ID vom Institut = IDREF vom Jahresbericht)

Im gegenwärtigen Datenbestand gibt es oft ein Jahresbericht aber mehrere Insitute. In diesen Fällen wird das vorhandene Jahresbericht für jedes vorhandene Institut erzeugt und zugeordnet. Die Nutzer können nicht erwünschte Jahresberichte löschen.