### PR TITLE
OA-384: Metadaten im DCAP.AP-Format ergänzen bzw. anpassen

### DIFF
--- a/src/main/resources/xsl/dcatcollection-2.0.xsl
+++ b/src/main/resources/xsl/dcatcollection-2.0.xsl
@@ -13,13 +13,15 @@
 
 
   <xsl:output method="xml" indent="yes" encoding="UTF-8" />
+  
+  <xsl:param name="WebApplicationBaseURL" />
 
   <!-- URLs in use -->
   <!-- open Agrar URLs -->
-  <xsl:variable name="OABaseURL">https://www.openagrar.de/</xsl:variable>
+  <xsl:variable name="OABaseURL" select="$WebApplicationBaseURL" />
   <xsl:variable name="OAURL"><xsl:value-of select="concat($OABaseURL, 'receive/')" /></xsl:variable>
   <xsl:variable name="OAFileURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRFileNodeServlet/')" /></xsl:variable>
-  <xsl:variable name="OAZIPURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRZipServlet/openagrar_derivate_')" /></xsl:variable>
+  <xsl:variable name="OAZIPURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRZipServlet/')" /></xsl:variable>
 
   <!-- Identifier URLs -->
   <xsl:variable name="rorURL">https://ror.org/</xsl:variable>
@@ -205,7 +207,7 @@
     <!-- Dataset documentation -->
     <xsl:for-each select="structure/derobjects/derobject">
       <xsl:if test="classification[contains(@categid,'documentation')]">
-        <foaf:page rdf:resource="{concat($OAFileURL, $MCRID, '/', maindoc)}"/>
+        <foaf:page rdf:resource="{concat($OAFileURL, @xlink:href, '/', maindoc)}"/>
       </xsl:if>
     </xsl:for-each>
     <!-- Do not create distribution if content-derivates are under embargo -->
@@ -218,43 +220,22 @@
         </xsl:for-each>
       </xsl:variable>     
       <xsl:if test="$ifs/der">
-        <xsl:choose>
-          <!-- count content derivates only -->
-          <xsl:when test="(count($ifs/der/mcr_directory/children//child[@type='file']) - 
-                    count(structure/derobjects/derobject/classification[contains(@categid,'documentation')])) &gt; 1">
-            <dcat:distribution>
-              <dcat:Distribution rdf:about="{concat($OAZIPURL, substring-after($MCRID, 'openagrar_mods_'))}">
-                <!-- Mandatory fields: dcat:accessURL -->
-                <dcat:accessURL rdf:resource="{concat($OAURL, $MCRID)}" />
-                <dcat:downloadURL rdf:resource="{concat($OAZIPURL, substring-after($MCRID, 'openagrar_mods_'))}" />
-                <dct:format rdf:resource="{concat($dctFileType, 'ZIP')}"/>
-                <xsl:if test="../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore']">
-                  <dct:license rdf:resource="{concat($dctLicenseURI, substring-after(../../../metadata/de.modsContainer/mods/mods:classification[@generator='mir_licenses2dcat_license-mycore'][1]/@valueURI, '#'))}"/>
-                </xsl:if> 
-              </dcat:Distribution>
-            </dcat:distribution>  
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:for-each select="structure/derobjects/derobject">
-              <!-- Create distribution only if derivate is of categorie "content" or "content_other_format" -->
-              <xsl:if test="classification[contains(@categid,'content')]">
-                <dcat:distribution>
-                  <dcat:Distribution rdf:about="{concat($OAFileURL, ../../../@ID, '/', maindoc)}">
-                    <!-- Mandatory fields: dcat:accessURL -->
-                    <dcat:accessURL rdf:resource="{concat($OAURL, ../../../@ID)}" />
-                    <dcat:downloadURL rdf:resource="{concat($OAFileURL, ../../../@ID, '/', maindoc)}" />
-                    <xsl:if test="contains($knownFormats, tokenize(maindoc,'\.')[last()])">
-					  <dct:format rdf:resource="{concat($dctFileType, upper-case(tokenize(maindoc,'\.')[last()]))}"/>
-					</xsl:if>
-                    <xsl:if test="../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore']">
-                      <dct:license rdf:resource="{concat($dctLicenseURI, substring-after(../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore'][1]/@valueURI, '#'))}"/>
-                    </xsl:if> 
-                  </dcat:Distribution>
-                </dcat:distribution>
+        <xsl:for-each select="structure/derobjects/derobject[classification[contains(@categid,'content')]]">
+          <!-- Create distribution only if derivate is of category "content" or "content_other_format" -->
+          <dcat:distribution>
+            <dcat:Distribution rdf:about="{concat($OAURL, $MCRID)}">
+              <!-- Mandatory fields: dcat:accessURL -->
+              <!-- TODO: check if derivate contains more than one file -->
+              <dcat:accessURL rdf:resource="{concat($OAFileURL, @xlink:href, '/', maindoc)}" />
+              <xsl:if test="contains($knownFormats, tokenize(maindoc,'\.')[last()])">
+                <dct:format rdf:resource="{concat($dctFileType, upper-case(tokenize(maindoc,'\.')[last()]))}"/>
               </xsl:if>
-            </xsl:for-each>
-          </xsl:otherwise>
-        </xsl:choose>
+              <xsl:if test="../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore']">
+                <dct:license rdf:resource="{concat($dctLicenseURI, substring-after(../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore'][1]/@valueURI, '#'))}"/>
+              </xsl:if>
+            </dcat:Distribution>
+          </dcat:distribution>
+        </xsl:for-each>
       </xsl:if>
     </xsl:if>
   </xsl:template>

--- a/src/main/resources/xsl/dcatcollection.xsl
+++ b/src/main/resources/xsl/dcatcollection.xsl
@@ -12,9 +12,11 @@
 
   <xsl:output method="xml" indent="yes" encoding="UTF-8" />
 
+  <xsl:param name="WebApplicationBaseURL" />
+
   <!-- URLs in use -->
   <!-- open Agrar URLs -->
-  <xsl:variable name="OABaseURL">https://www.openagrar.de/</xsl:variable>
+  <xsl:variable name="OABaseURL" select="$WebApplicationBaseURL" />
   <xsl:variable name="OAURL"><xsl:value-of select="concat($OABaseURL, 'receive/')" /></xsl:variable>
   <xsl:variable name="OAFileURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRFileNodeServlet/')" /></xsl:variable>
 

--- a/src/main/resources/xsl/dcatcollectionHVD-2.0.xsl
+++ b/src/main/resources/xsl/dcatcollectionHVD-2.0.xsl
@@ -16,12 +16,14 @@
 
   <xsl:output method="xml" indent="yes" encoding="UTF-8" />
 
+  <xsl:param name="WebApplicationBaseURL" />
+
   <!-- URLs in use -->
   <!-- open Agrar URLs -->
-  <xsl:variable name="OABaseURL">https://www.openagrar.de/</xsl:variable>
+  <xsl:variable name="OABaseURL" select="$WebApplicationBaseURL" />
   <xsl:variable name="OAURL"><xsl:value-of select="concat($OABaseURL, 'receive/')" /></xsl:variable>
   <xsl:variable name="OAFileURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRFileNodeServlet/')" /></xsl:variable>
-  <xsl:variable name="OAZIPURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRZipServlet/openagrar_derivate_')" /></xsl:variable>
+  <xsl:variable name="OAZIPURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRZipServlet/')" /></xsl:variable>
 
   <!-- Identifier URLs -->
   <xsl:variable name="doiURL">https://doi.org/</xsl:variable>
@@ -210,7 +212,7 @@
     <!-- Dataset documentation -->
     <xsl:for-each select="structure/derobjects/derobject">
       <xsl:if test="classification[contains(@categid,'documentation')]">
-        <foaf:page rdf:resource="{concat($OAFileURL, $MCRID, '/', maindoc)}"/>
+        <foaf:page rdf:resource="{concat($OAFileURL, @xlink:href, '/', maindoc)}"/>
       </xsl:if>
     </xsl:for-each>
     <!-- Do not create distribution if content-derivates are under embargo -->
@@ -223,50 +225,28 @@
         </xsl:for-each>
       </xsl:variable>     
       <xsl:if test="$ifs/der">
-        <xsl:choose>
-	    <xsl:when test="(count($ifs/der/mcr_directory/children//child[@type='file']) - 
-	              count(structure/derobjects/derobject/classification[contains(@categid,'documentation')])) &gt; 1">
-	      <dcat:distribution>
-            <dcat:Distribution rdf:resource="{concat($OAZIPURL, substring-after($MCRID, 'openagrar_mods_'))}">
+        <xsl:for-each select="structure/derobjects/derobject[classification[contains(@categid,'content')]]">
+          <!-- Create distribution only if derivate is of category "content" or "content_other_format" -->
+          <dcat:distribution>
+            <dcat:Distribution rdf:about="{concat($OAURL, $MCRID)}">
               <!-- Mandatory fields: dcat:accessURL -->
-              <dcat:accessURL rdf:resource="{concat($OAURL, $MCRID)}" />
-              <dcat:downloadURL rdf:resource="{concat($OAZIPURL, substring-after($MCRID, 'openagrar_mods_'))}" />
-              <dct:format rdf:resource="{concat($dctFileType, 'ZIP')}"/>
-              <foaf:page rdf:resource="{concat($OAURL, $MCRID)}" />
-			  <xsl:if test="../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore']">
-			    <dct:license rdf:resource="{concat($dctLicenseURI, substring-after(../../../metadata/de.modsContainer/mods/mods:classification[@generator='mir_licenses2dcat_license-mycore'][1]/@valueURI, '#'))}"/>
-			  </xsl:if> 
-            </dcat:Distribution>
-          </dcat:distribution>	
-        </xsl:when>
-        <xsl:otherwise>
-	      <xsl:for-each select="structure/derobjects/derobject">
-	        <!-- Create distribution only if derivate is of categorie "content" or "content_other_format" -->
-	        <xsl:if test="classification[contains(@categid,'content')]">
-              <dcat:distribution>
-                <dcat:Distribution rdf:resource="{concat($OAFileURL, ../../../@ID, '/', maindoc)}">
-                  <!-- Mandatory fields: dcat:accessURL -->
-                  <dcat:accessURL rdf:resource="{concat($OAURL, ../../../@ID)}" />
-                  <dcat:downloadURL rdf:resource="{concat($OAFileURL, ../../../@ID, '/', maindoc)}" />
-                  <xsl:if test="contains($knownFormats, tokenize(maindoc,'\.')[last()])">
-						<dct:format rdf:resource="{concat($dctFileType, upper-case(tokenize(maindoc,'\.')[last()]))}"/>
-					</xsl:if>
-                  <foaf:page rdf:resource="{concat($OAURL, $MCRID)}" />
-                  <xsl:if test="../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore']">
-				    <dct:license rdf:resource="{concat($dctLicenseURI, substring-after(../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore'][1]/@valueURI, '#'))}"/>
-				  </xsl:if> 
-                </dcat:Distribution>
-               </dcat:distribution>
+              <!-- TODO: check if derivate contains more than one file -->
+              <dcat:accessURL rdf:resource="{concat($OAFileURL, @xlink:href, '/', maindoc)}" />
+              <xsl:if test="contains($knownFormats, tokenize(maindoc,'\.')[last()])">
+                <dct:format rdf:resource="{concat($dctFileType, upper-case(tokenize(maindoc,'\.')[last()]))}"/>
               </xsl:if>
-            </xsl:for-each>
-          </xsl:otherwise>
-        </xsl:choose>
+              <xsl:if test="../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore']">
+                <dct:license rdf:resource="{concat($dctLicenseURI, substring-after(../../../metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@generator='mir_licenses2dcat_license-mycore'][1]/@valueURI, '#'))}"/>
+              </xsl:if>
+            </dcat:Distribution>
+          </dcat:distribution>
+        </xsl:for-each>
       </xsl:if>
     </xsl:if>
   </xsl:template>
 
   <xsl:template name="identifier">
-	<dct:identifier>
+    <dct:identifier>
       <xsl:value-of select="../../../../@ID" />
     </dct:identifier>
   </xsl:template>

--- a/src/main/resources/xsl/mods2dcatapde.xsl
+++ b/src/main/resources/xsl/mods2dcatapde.xsl
@@ -12,9 +12,11 @@
 
     <xsl:output method="xml" indent="yes" encoding="UTF-8" />
     
+    <xsl:param name="WebApplicationBaseURL" />
+    
     <!-- URLs in use -->
     <!-- open Agrar URLs -->
-    <xsl:variable name="OABaseURL">https://www.openagrar.de/</xsl:variable>
+    <xsl:variable name="OABaseURL" select="$WebApplicationBaseURL" />
     <xsl:variable name="OAURL"><xsl:value-of select="concat($OABaseURL, 'receive/')" /></xsl:variable>
     <xsl:variable name="OAFileURL"><xsl:value-of select="concat($OABaseURL, 'servlets/MCRFileNodeServlet/')" /></xsl:variable>
     


### PR DESCRIPTION
Korrekturen:

1. foaf:page/foaf:document-Link korrigiert (openagrar_mods_<NR> => openagrar_derivate_<NR>)
2. Falls ROR für Contributor vorhanden, wird die ROR-ID als rdf:abaout für die PersonID genommen.

