### PR TITLE
OA-339 Add bfr_all to MCR.Rest.JWT.Roles

### DIFF
--- a/src/main/resources/config/reposis_openagrar/mycore.properties
+++ b/src/main/resources/config/reposis_openagrar/mycore.properties
@@ -141,6 +141,9 @@ MCR.OAIDataProvider.OAI2.Sets.govdata.Query=mods.type:research_data AND state:pu
 # Erlaubt Administratoren änderungen an Daten die bereits eine URN oder DOI haben
 # add new role to upload file to documents with doi. Used for sciflow importer
   MIR.Strategy.EditPIRoles=admin,piadmin
+  
+# Allow BfR User to get Derivate view in metadatapage for derivate restricted to bfr_intranet
+  MCR.Rest.JWT.Roles=%MCR.Rest.JWT.Roles%,mir_institutes:bfr_all
 
 # BfR
   MCR.PI.Generator.DateDOIBfr=org.mycore.pi.MCRGenericPIGenerator


### PR DESCRIPTION
Allow BfR User to get Derivate view in metadatapage for derivate restricted to bfr_intranet