### PR TITLE
REP-1106 Use shared URN OAI set configuration

### DIFF
--- a/src/main/resources/config/reposis_openagrar/mycore.properties
+++ b/src/main/resources/config/reposis_openagrar/mycore.properties
@@ -78,7 +78,10 @@ MCR.OAIDataProvider.OAI2.DescriptionURI.Rights=webapp:oai/oai-rights.xml
 MCR.OAIDataProvider.OAI2.RecordSampleID=openagrar_mods_00000479
 
 MCR.OAIDataProvider.OAI2.MetadataFormats=oai_dc,mods,marcxml,epicur,oai_datacite,xMetaDissPlus
-MCR.OAIDataProvider.OAI2.Sets=doc-type,open_access,openaire,driver,ec_fundedresources,GENRE,ddc,institute,govdata,urn,xmetadissplus
+MCR.OAIDataProvider.OAI2.Sets=doc-type,open_access,openaire,driver,ec_fundedresources,GENRE,ddc,institute,govdata,xmetadissplus
+
+# Enable the URN set configured by reposis_common.
+MCR.OAIDataProvider.OAI2.Sets=%MCR.OAIDataProvider.OAI2.Sets%,urn
 
 MCR.OAIDataProvider.MetadataFormat.oai_datacite.Namespace=http://schema.datacite.org/oai/oai-1.0/
 MCR.OAIDataProvider.MetadataFormat.oai_datacite.Schema=http://schema.datacite.org/oai/oai-1.0/oai_datacite.xsd
@@ -87,10 +90,6 @@ MCR.OAIDataProvider.MetadataFormat.oai_datacite.Schema=http://schema.datacite.or
 # (Genre Forschungsdaten UND physisches Dokument UND offene Lizenz) ODER (Forschungsdaten KEIN physisches Dokument UND offene Lizenz UND DOI) nur  Status \u201Epublished\u201C
 MCR.OAIDataProvider.OAI2.Sets.govdata.URI=webapp:oai/set_govdata.xml
 MCR.OAIDataProvider.OAI2.Sets.govdata.Query=mods.type:research_data AND state:published AND category.top:"mir_licenses:oa" AND (derCount:{0 TO *] OR mods.identifier:10.*)
-
-  # Define URN set
-  MCR.OAIDataProvider.OAI2.MapSetToQuery.urn=mods.identifier:urn\\:nbn\\:de\\:gbv\\:253-*
-  MCR.OAIDataProvider.OAI2.Sets.urn=webapp:oai/set_urn.xml
 
   # xMetaDissPlus
   MCR.OAIDataProvider.MetadataFormat.xMetaDissPlus.Schema=http://files.dnb.de/standards/xmetadissplus/xmetadissplus.xsd


### PR DESCRIPTION
## Changes

- enable the `urn` OAI set configured by `reposis_common`
- use the shared query `mods.identifier.type.urn:* AND state:published`
- remove the project-specific URN set configuration where present

This is the properties-only change corresponding to gbv/reposis_vzg#5.